### PR TITLE
RMHDR-242, RMHDR-243, RMHDR-244 Updates and Fixes

### DIFF
--- a/scripts/egress/egress.R
+++ b/scripts/egress/egress.R
@@ -14,25 +14,25 @@ latest_commit_tree_url <-
 
 recoverSummarizeR::store_in_syn(
   synFolderID = synFolderID, 
-  filepath = file.path(outputConceptsDir, "final_output_concepts.csv"), 
+  filepath = file.path(outputConceptsDir, "output_concepts.csv"), 
   used_param = c(ontologyFileID, parquetDirID, selectedVarsFileID), 
-  executed_param = gh::gh()
+  executed_param = latest_commit_tree_url
 )
 cat(glue::glue("Output concepts stored at {synFolderID}"), "\n")
 
 file_name <- "concepts_map.csv"
 write.csv(concept_map, file = file_name, row.names = F)
-store_in_syn(synFolderID, 'concepts_map.csv', used_param = ontologyFileID)
+store_in_syn(synFolderID, file_name, used_param = ontologyFileID)
 cat(glue::glue("The input concept map used was stored at {synFolderID} as '{file_name}'"), "\n")
 
 file_name <- "selected_vars.csv"
 write.csv(selected_vars, file = file_name, row.names = F)
-store_in_syn(synFolderID, 'selected_vars.csv', used_param = selectedVarsFileID)
+store_in_syn(synFolderID, file_name, used_param = selectedVarsFileID)
 cat(glue::glue("The input variable list used was stored at {synFolderID} as '{file_name}'"), "\n")
 
 rm(latest_commit,
    latest_commit_tree_url,
    file_name
- )
+)
 
 cat("Finished egress\n\n")

--- a/scripts/process-data/fitbitactivitylogs.R
+++ b/scripts/process-data/fitbitactivitylogs.R
@@ -80,6 +80,16 @@ output_concepts <-
   dplyr::filter(nval_num != "<null>" | tval_char != "<null>")
 cat("recoverSummarizeR::process_df() completed.\n")
 
+# Identify the participants who have output concepts derived from fitbit variables
+fitbit_participants <- 
+  sort(unique(output_concepts$participantidentifier)) %>% 
+  as.data.frame() %>% 
+  dplyr::rename(participantidentifier = ".")
+
+fitbit_participants %>% 
+  write.csv(file.path(outputConceptsDir, "fitbit_participants.csv"), 
+            row.names = F)
+
 # Write the output
 output_concepts %>% 
   write.csv(file.path(outputConceptsDir, glue::glue("{dataset}.csv")), row.names = F)
@@ -100,4 +110,5 @@ rm(dataset,
    upper_bound,
    df_melted_filtered, 
    df_summarized, 
-   output_concepts)
+   output_concepts,
+   fitbit_participants)

--- a/scripts/process-data/fitbitdailydata.R
+++ b/scripts/process-data/fitbitdailydata.R
@@ -13,12 +13,13 @@ vars <-
 # Load the desired subset of this dataset in memory
 df <- 
   arrow::open_dataset(file.path(downloadLocation, glue::glue("dataset_{dataset}"))) %>% 
-  mutate(Tracker_Steps = as.numeric(Tracker_Steps),
+  mutate(Steps = as.numeric(Steps),
          HeartRateIntradayMinuteCount = as.numeric(HeartRateIntradayMinuteCount)) %>% 
-  filter(Tracker_Steps != 0, 
-         HeartRateIntradayMinuteCount != 0 | !is.na(HeartRateIntradayMinuteCount)) %>% 
-  select(all_of(vars)) %>% 
-  collect()
+  select(all_of(c(vars, "HeartRateIntradayMinuteCount"))) %>% 
+  collect() %>% 
+  filter((!(Steps==0 & (HeartRateIntradayMinuteCount==0 | is.na(HeartRateIntradayMinuteCount)))) %>%
+           tidyr::replace_na(TRUE)) %>% 
+  dplyr::select(-HeartRateIntradayMinuteCount)
 
 colnames(df) <- tolower(colnames(df))
 

--- a/scripts/process-data/fitbitdailydata.R
+++ b/scripts/process-data/fitbitdailydata.R
@@ -91,6 +91,24 @@ output_concepts <-
   dplyr::filter(nval_num != "<null>" | tval_char != "<null>")
 cat("recoverSummarizeR::process_df() completed.\n")
 
+# Identify the participants who have output concepts derived from fitbit variables
+curr_fitbit_participants <- 
+  sort(unique(output_concepts$participantidentifier)) %>% 
+  as.data.frame() %>% 
+  dplyr::rename(participantidentifier = ".")
+
+prev_fitbit_participants <- 
+  read.csv(file.path(outputConceptsDir, "fitbit_participants.csv"))
+
+fitbit_participants <- 
+  dplyr::bind_rows(prev_fitbit_participants, 
+                   curr_fitbit_participants) %>% 
+  distinct()
+
+fitbit_participants %>% 
+  write.csv(file.path(outputConceptsDir, "fitbit_participants.csv"), 
+            row.names = F)
+
 # Write the output
 output_concepts %>% 
   write.csv(file.path(outputConceptsDir, glue::glue("{dataset}.csv")), row.names = F)
@@ -111,4 +129,7 @@ rm(dataset,
    upper_bound,
    df_melted_filtered, 
    df_summarized, 
-   output_concepts)
+   output_concepts,
+   curr_fitbit_participants, 
+   prev_fitbit_participants, 
+   fitbit_participants)

--- a/scripts/process-data/fitbitintradaycombined.R
+++ b/scripts/process-data/fitbitintradaycombined.R
@@ -105,6 +105,24 @@ output_concepts <-
   dplyr::filter(nval_num != "<null>" | tval_char != "<null>")
 cat("recoverSummarizeR::process_df() completed.\n")
 
+# Identify the participants who have output concepts derived from fitbit variables
+curr_fitbit_participants <- 
+  sort(unique(output_concepts$participantidentifier)) %>% 
+  as.data.frame() %>% 
+  dplyr::rename(participantidentifier = ".")
+
+prev_fitbit_participants <- 
+  read.csv(file.path(outputConceptsDir, "fitbit_participants.csv"))
+
+fitbit_participants <- 
+  dplyr::bind_rows(prev_fitbit_participants, 
+                   curr_fitbit_participants) %>% 
+  distinct()
+
+fitbit_participants %>% 
+  write.csv(file.path(outputConceptsDir, "fitbit_participants.csv"), 
+            row.names = F)
+
 # Write the output
 output_concepts %>% 
   write.csv(file.path(outputConceptsDir, glue::glue("{dataset}.csv")), row.names = F)
@@ -125,4 +143,7 @@ rm(dataset,
    upper_bound,
    df_melted_filtered, 
    df_summarized, 
-   output_concepts)
+   output_concepts,
+   curr_fitbit_participants, 
+   prev_fitbit_participants, 
+   fitbit_participants)

--- a/scripts/process-data/fitbitsleeplogs.R
+++ b/scripts/process-data/fitbitsleeplogs.R
@@ -348,6 +348,24 @@ output_concepts <-
   dplyr::filter(nval_num != "<null>" | tval_char != "<null>")
 cat("recoverSummarizeR::process_df() completed.\n")
 
+# Identify the participants who have output concepts derived from fitbit variables
+curr_fitbit_participants <- 
+  sort(unique(output_concepts$participantidentifier)) %>% 
+  as.data.frame() %>% 
+  dplyr::rename(participantidentifier = ".")
+
+prev_fitbit_participants <- 
+  read.csv(file.path(outputConceptsDir, "fitbit_participants.csv"))
+
+fitbit_participants <- 
+  dplyr::bind_rows(prev_fitbit_participants, 
+                   curr_fitbit_participants) %>% 
+  distinct()
+
+fitbit_participants %>% 
+  write.csv(file.path(outputConceptsDir, "fitbit_participants.csv"), 
+            row.names = F)
+
 # Write the output
 output_concepts %>% 
   write.csv(file.path(outputConceptsDir, glue::glue("{dataset}.csv")), row.names = F)
@@ -380,4 +398,7 @@ rm(sleeplogs_stat_summarize,
    numepisodes_df_summarized_alltime,
    numepisodes_df_summarized_weekly,
    final_df_summarized,
-   output_concepts)
+   output_concepts,
+   curr_fitbit_participants, 
+   prev_fitbit_participants, 
+   fitbit_participants)

--- a/scripts/process-data/participant_devices.R
+++ b/scripts/process-data/participant_devices.R
@@ -39,7 +39,7 @@ hk_participants <- read.csv(file.path(outputConceptsDir, "hk_participants.csv"))
 
 df$healthkitv2samples <- 
   df$healthkitv2samples %>% 
-  dplyr::filter(participantidentifier %in% hk_participants) %>%
+  dplyr::filter(participantidentifier %in% hk_participants$participantidentifier) %>%
   mutate(type = case_when(device_manufacturer %in% c("Apple", "Apple Inc.") ~ "Apple",
                           device_manufacturer %in% c("Garmin") ~ "Garmin",
                           device_manufacturer %in% c("Polar Electro Oy") ~ "Polar",

--- a/scripts/process-data/participant_devices.R
+++ b/scripts/process-data/participant_devices.R
@@ -5,8 +5,11 @@ dataset <- c("fitbitdevices", "healthkitv2samples")
 cat(glue::glue("Transforming device data for {dataset}"),"\n")
 
 # Get variables for this dataset
-vars <- list(fitbitdevices = c("ParticipantIdentifier", "Device", "Date"), 
-             healthkitv2samples = c("ParticipantIdentifier", "Device_Model", "Device_Manufacturer", "StartDate", "Date"))
+vars <- list(fitbitdevices = c("ParticipantIdentifier", 
+                               "Device"),
+             healthkitv2samples = c("ParticipantIdentifier", 
+                                    "Device_Model", 
+                                    "Device_Manufacturer"))
 
 # Load the desired subset of this dataset in memory
 df <- 
@@ -23,13 +26,20 @@ df <-
     return(x)
   })
 
-# Add a variable to indicate device type
+# Get lists of participants that i2b2 summaries are already generated for and 
+# add a variable to indicate device type
+fitbit_participants <- read.csv(file.path(outputConceptsDir, "fitbit_participants.csv"))
+
 df$fitbitdevices <- 
   df$fitbitdevices %>% 
-  mutate(type = ifelse(is.na(device) | device == "", NA, "fitbit"))
+  dplyr::filter(participantidentifier %in% fitbit_participants$participantidentifier) %>%
+  dplyr::mutate(type = ifelse(is.na(device) | device == "", NA, "fitbit"))
+
+hk_participants <- read.csv(file.path(outputConceptsDir, "hk_participants.csv"))
 
 df$healthkitv2samples <- 
   df$healthkitv2samples %>% 
+  dplyr::filter(participantidentifier %in% hk_participants) %>%
   mutate(type = case_when(device_manufacturer %in% c("Apple", "Apple Inc.") ~ "Apple",
                           device_manufacturer %in% c("Garmin") ~ "Garmin",
                           device_manufacturer %in% c("Polar Electro Oy") ~ "Polar",
@@ -40,27 +50,36 @@ df$healthkitv2samples <-
 # frame and summarise the unique device types for each participant into i2b2 summary format
 df_joined <- 
   bind_rows(df$fitbitdevices %>% 
-              select(all_of(c("participantidentifier", "type", "date"))), 
+              select(all_of(c("participantidentifier", "type"))), 
             df$healthkitv2samples %>% 
-              select(all_of(c("participantidentifier", "type", "startdate", "date")))) %>% 
-  select(all_of(c("participantidentifier", "type", "startdate", "date"))) %>% 
-  rename(enddate = date) %>% 
-  mutate(startdate = lubridate::as_date(startdate),
-         enddate = lubridate::as_date(enddate)) %>% 
-  group_by(participantidentifier, startdate, enddate) %>% 
+              select(all_of(c("participantidentifier", "type")))) %>% 
+  group_by(participantidentifier) %>% 
   summarise(type = toString(sort(unique(type)))) %>% 
   mutate(concept = "mhp:device") %>% 
   rename(value = type) %>% 
-  select(all_of(c("participantidentifier", "startdate", "enddate", "concept", "value"))) %>% 
+  select(all_of(c("participantidentifier", "concept", "value"))) %>% 
   ungroup()
 
 # Add i2b2 columns from concept map (ontology file) and clean the output
+concept_map_concepts <- "CONCEPT_CD"
+concept_map_units <- "UNITS_CD"
 output_concepts <- 
-  process_df(df_joined, concept_map, concept_map_concepts = "CONCEPT_CD", concept_map_units = "UNITS_CD") %>% 
+  df_joined %>% 
+  dplyr::mutate(valtype_cd = dplyr::case_when(class(value) == "numeric" ~ "N", 
+                                              class(value) == "character" ~ "T")) %>%
+  dplyr::mutate(nval_num = as.numeric(dplyr::case_when(valtype_cd == "N" ~ value)),
+                tval_char = as.character(dplyr::case_when(valtype_cd == "T" ~ value))) %>%
+  dplyr::select(dplyr::setdiff(names(.), "value")) %>%
+  dplyr::left_join(dplyr::select(concept_map, dplyr::all_of(c(concept_map_concepts, concept_map_units))),
+                   by = c("concept" = concept_map_concepts)) %>% 
+  tidyr::drop_na(valtype_cd) %>% 
   dplyr::arrange(concept) %>% 
   dplyr::mutate(dplyr::across(.cols = dplyr::everything(), .fns = as.character)) %>% 
   replace(is.na(.), "<null>") %>% 
-  dplyr::filter(nval_num != "<null>" | tval_char != "<null>")
+  dplyr::filter(nval_num != "<null>" | tval_char != "<null>") %>% 
+  mutate(startdate = "<null>", enddate = "<null>") %>% 
+  dplyr::select(participantidentifier, startdate, enddate, 
+                concept, valtype_cd, nval_num, tval_char, UNITS_CD)
 cat("recoverSummarizeR::process_df() completed.\n")
 
 # Write the output
@@ -74,5 +93,9 @@ cat(glue::glue("Finished tansforming device data for {dataset}"),"\n\n")
 rm(dataset,
    vars,
    df,
+   fitbit_participants,
+   hk_participants,
    df_joined,
+   concept_map_concepts, 
+   concept_map_units,
    output_concepts)

--- a/scripts/write-output/final-output-concepts.R
+++ b/scripts/write-output/final-output-concepts.R
@@ -11,6 +11,7 @@ output_concepts <-
     output_concepts_path <- file.path(outputConceptsDir, paste0(x, ".csv"))
     if (file.exists(output_concepts_path)) {
       read.csv(output_concepts_path, 
+               stringsAsFactors = F,
                tryLogical = F,
                colClasses = "character")
     }

--- a/scripts/write-output/final-output-concepts.R
+++ b/scripts/write-output/final-output-concepts.R
@@ -3,7 +3,6 @@ cat("Creating final output concepts\n")
 # Read each dataset's (intermediate) i2b2 output concepts CSV file, combine 
 # them, and de-duplicate data if it already exists (fitbit data is highest 
 # priority, then healthkit, then other)
-
 datasets <- selected_vars$Export %>% unique()
 datasets[datasets %in% c("fitbitdevices")] <- "participant_devices"
 
@@ -35,7 +34,6 @@ combined_device <- combined_device[!duplicated(combined_device), ]
 combined_output_concepts <- bind_rows(combined_device, 
                                       combined_fitbit, 
                                       combined_healthkit)
-# dupes <- combined_output_concepts[duplicated(combined_output_concepts),]
 combined_output_concepts <- combined_output_concepts[!duplicated(combined_output_concepts), ]
 
 combined_output_concepts %>% 

--- a/scripts/write-output/final-output-concepts.R
+++ b/scripts/write-output/final-output-concepts.R
@@ -39,8 +39,8 @@ combined_output_concepts <- bind_rows(combined_device,
 combined_output_concepts <- combined_output_concepts[!duplicated(combined_output_concepts), ]
 
 combined_output_concepts %>% 
-  write.csv(file.path(outputConceptsDir, "final_output_concepts.csv"), row.names = F)
-cat(glue::glue("output_concepts written to {file.path(outputConceptsDir, 'final_output_concepts.csv')}"),"\n")
+  write.csv(file.path(outputConceptsDir, "output_concepts.csv"), row.names = F)
+cat(glue::glue("output_concepts written to {file.path(outputConceptsDir, 'output_concepts.csv')}"),"\n")
 
 # Remove objects created here from the global environment
 rm(datasets,


### PR DESCRIPTION
## Major Changes

1. Fix the preliminary filtering in `fitbitdailydata.R`
    - [RMHDR-242](https://sagebionetworks.jira.com/browse/RMHDR-242)
2. Fix the `mhp:device` summary generation by not incorporating dates in identifying the device used by each participant for whom i2b2 summaries have been generated
    - [RMHDR-243](https://sagebionetworks.jira.com/browse/RMHDR-243)
3. In each `process-data` script for fitbit datasets, identify the participants for whom i2b2 summaries have been generated
    - In each `process-data` script for healthkit datasets, exclude the participants found in the fitbit participants list above
    - [RMHDR-244](https://sagebionetworks.jira.com/browse/RMHDR-244)
