### PR TITLE
Scale healthkit OxygenSaturation values

### DIFF
--- a/scripts/egress/egress.R
+++ b/scripts/egress/egress.R
@@ -20,17 +20,17 @@ recoverSummarizeR::store_in_syn(
   used_param = c(ontologyFileID, parquetDirID, selectedVarsFileID), 
   executed_param = latest_commit_tree_url
 )
-cat(glue::glue("Output concepts stored at {synFolderID}"), "\n")
+cat(glue::glue("Output concepts stored at {synFolderID}"), "\n\n")
 
 file_name <- "concepts_map.csv"
 write.csv(concept_map, file = file_name, row.names = F)
 store_in_syn(synFolderID, file_name, used_param = ontologyFileID)
-cat(glue::glue("The input concept map used was stored at {synFolderID} as '{file_name}'"), "\n")
+cat(glue::glue("The input concept map used was stored at {synFolderID} as '{file_name}'"), "\n\n")
 
 file_name <- "selected_vars.csv"
 write.csv(selected_vars, file = file_name, row.names = F)
 store_in_syn(synFolderID, file_name, used_param = selectedVarsFileID)
-cat(glue::glue("The input variable list used was stored at {synFolderID} as '{file_name}'"), "\n")
+cat(glue::glue("The input variable list used was stored at {synFolderID} as '{file_name}'"), "\n\n")
 
 rm(latest_commit,
    latest_commit_tree_url,

--- a/scripts/process-data/healthkitv2samples.R
+++ b/scripts/process-data/healthkitv2samples.R
@@ -36,6 +36,8 @@ df <-
   mutate(Value = as.numeric(Value)) %>% 
   collect()
 
+df$Value[df$concept=="OxygenSaturation"] <- df$Value[df$concept=="OxygenSaturation"]*100
+
 colnames(df) <- tolower(colnames(df))
 
 # Get QA/QC ranges for variables and exclude values outside the ranges
@@ -49,9 +51,6 @@ bounds <-
   data.frame(Variable = c("HeartRate", "RespiratoryRate", "OxygenSaturation", "HeartRateVariability"),
              Lower_Bound = sapply(criteria, function(x) selected_vars$Lower_Bound[x]), 
              Upper_Bound = sapply(criteria, function(x) selected_vars$Upper_Bound[x]))
-
-bounds$Lower_Bound[bounds$Variable=="OxygenSaturation"] <- bounds$Lower_Bound[bounds$Variable=="OxygenSaturation"]/100
-bounds$Upper_Bound[bounds$Variable=="OxygenSaturation"] <- bounds$Upper_Bound[bounds$Variable=="OxygenSaturation"]/100
 
 df_filtered <- df
 for (i in 1:nrow(bounds)) {


### PR DESCRIPTION
## Major Changes

1. Scale `OxygenSaturation` in the `healthkitv2samples` dataset to be in the range 0-100 (vs. previously 0-1), which would match the range of `SpO2Avg` in the `fitbitdailydata` dataset (0-100). 

## Minor Changes

1. Add an extra newline character to each call to cat() in `scripts/egress/egress.R`
