### PR TITLE
Assign startdate values for device summaries

### DIFF
--- a/scripts/write-output/final-output-concepts.R
+++ b/scripts/write-output/final-output-concepts.R
@@ -44,7 +44,10 @@ valid_participants <-
 
 combined_output_concepts <- 
   combined_output_concepts %>% 
-  filter(participantidentifier %in% valid_participants)
+  filter(participantidentifier %in% valid_participants) %>% 
+  group_by(participantidentifier) %>% 
+  mutate(startdate = ifelse(concept=="mhp:device", min(startdate[concept != "mhp:device"], na.rm = TRUE), startdate)) %>%
+  ungroup()
 
 combined_output_concepts %>% 
   write.csv(file.path(outputConceptsDir, "output_concepts.csv"), row.names = F)


### PR DESCRIPTION
## Major Changes

1. For each participant, assign their earliest non-null start date value to the start date for their `mhp:device` concept summary