### PR TITLE
Assign startdate values for device summaries

### DIFF
--- a/scripts/write-output/final-output-concepts.R
+++ b/scripts/write-output/final-output-concepts.R
@@ -44,7 +44,10 @@ valid_participants <-
 
 combined_output_concepts <- 
   combined_output_concepts %>% 
-  filter(participantidentifier %in% valid_participants)
+  filter(participantidentifier %in% valid_participants) %>% 
+  group_by(participantidentifier) %>% 
+  mutate(startdate = ifelse(concept=="mhp:device", min(startdate[concept != "mhp:device"], na.rm = TRUE), startdate)) %>%
+  ungroup()
 
 combined_output_concepts %>% 
   write.csv(file.path(outputConceptsDir, "output_concepts.csv"), row.names = F)

--- a/scripts/write-output/final-output-concepts.R
+++ b/scripts/write-output/final-output-concepts.R
@@ -37,6 +37,15 @@ combined_output_concepts <- bind_rows(combined_device,
                                       combined_healthkit)
 combined_output_concepts <- combined_output_concepts[!duplicated(combined_output_concepts), ]
 
+valid_participants <- 
+  read.csv(file.path(outputConceptsDir, "participant_devices.csv")) %>% 
+  distinct(participantidentifier) %>% 
+  pull()
+
+combined_output_concepts <- 
+  combined_output_concepts %>% 
+  filter(participantidentifier %in% valid_participants)
+
 combined_output_concepts %>% 
   write.csv(file.path(outputConceptsDir, "output_concepts.csv"), row.names = F)
 cat(glue::glue("output_concepts written to {file.path(outputConceptsDir, 'output_concepts.csv')}"),"\n")


### PR DESCRIPTION
## Major Changes

1. For each participant, assign their earliest non-null start date value to the start date for their `mhp:device` concept summary