### PR TITLE
RMHDR-258 New i2b2 Measures for 2024 Q3

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -3,7 +3,7 @@ default:
 
 staging:
   ontologyFileID: syn52050046
-  parquetDirID: syn59800646
+  parquetDirID: syn61250818
   # dataset_name_filter: !expr c("fitbit","healthkit")
   deleteExistingDir: FALSE
   concept_replacements: !expr c("mins" = "minutes",
@@ -18,7 +18,7 @@ staging:
   synFolderID: syn52504335
   # method: sts
   s3bucket: recover-main-project
-  s3basekey: main/archive/2024-05-21/
+  s3basekey: main/archive/2024-06-13/
   downloadLocation: ./temp-parquet
   selectedVarsFileID: syn53503994
   outputConceptsDir: ./temp-output-concepts

--- a/pipeline/run-pipeline.R
+++ b/pipeline/run-pipeline.R
@@ -1,6 +1,6 @@
 # Get config variables
 list2env(x = config::get(file = "config/config.yml", 
-                         config = "prod"),
+                         config = "staging"),
          envir = .GlobalEnv)
 
 # Fetch data

--- a/scripts/process-data/fitbitsleeplogs.R
+++ b/scripts/process-data/fitbitsleeplogs.R
@@ -269,6 +269,34 @@ rem_onset_latency <-
       units = "secs")) %>% 
   ungroup()
 
+tmp <- 
+  sleeplogsdetails_df %>% 
+  filter(Value=="rem") %>% 
+  filter(IsMainSleep==TRUE) %>% 
+  mutate(remDuration = lubridate::ymd_hms(EndDate)-lubridate::ymd_hms(StartDate))
+
+tmp2 <- 
+  tmp %>% 
+  group_by(LogId) %>%
+  summarise(totalREM = sum(remDuration)) %>% 
+  ungroup()
+
+tmp3 <- 
+  df %>% 
+  select(LogId, ParticipantIdentifier, SleepLevelRem, IsMainSleep) %>% 
+  filter(IsMainSleep==TRUE) %>% 
+  left_join(ungroup(tmp2), by = join_by(LogId)) %>% 
+  mutate(minsTotalREM = as.numeric(totalREM/60)) %>% 
+  mutate(SleepLevelRem = as.numeric(SleepLevelRem)) %>% 
+  mutate(diff = SleepLevelRem-minsTotalREM)
+
+sleeplogsdetails_df %>% 
+  filter(if_any(c(StartDate, EndDate, Value, Type), ~ . != "")) %>% 
+  filter(IsMainSleep==TRUE) %>% 
+  group_by(LogId) %>% 
+  arrange(StartDate, .by_group = TRUE) %>% 
+  View
+
 # Merge the original df with the numawakenings df to create a united df
 df_joined <- left_join(x = df, y = numawakenings_logid_filtered, by = "LogId")
 

--- a/scripts/process-data/fitbitsleeplogs.R
+++ b/scripts/process-data/fitbitsleeplogs.R
@@ -215,6 +215,7 @@ sleeplogsdetails_df <-
   arrow::open_dataset(file.path(downloadLocation, "dataset_fitbitsleeplogs_sleeplogdetails")) %>% 
   select(all_of(sleeplogsdetails_vars)) %>% 
   collect() %>% 
+  distinct() %>% 
   left_join(y = (df %>% select(LogId, IsMainSleep)), by = "LogId") %>% 
   group_by(LogId) %>% 
   arrange(StartDate, .by_group = TRUE) %>% 
@@ -294,8 +295,8 @@ sleeplogsdetails_df %>%
   filter(if_any(c(StartDate, EndDate, Value, Type), ~ . != "")) %>% 
   filter(IsMainSleep==TRUE) %>% 
   group_by(LogId) %>% 
-  arrange(StartDate, .by_group = TRUE) %>% 
-  View
+  arrange(StartDate, .by_group = TRUE)
+
 
 # Merge the original df with the numawakenings df to create a united df
 df_joined <- left_join(x = df, y = numawakenings_logid_filtered, by = "LogId")


### PR DESCRIPTION
## Major Changes

1. Calculate **REM Onset Latency** and **REM Sleep Fragmentation Index** for each `fitbitsleeplogs_sleeplogdetails` `LogId` (a sleep event) for each `ParticipantIdentifier`
    - [RMHDR-258](https://sagebionetworks.jira.com/browse/RMHDR-258)
3. Use `id` and/or `ParticipantIdentifier` with `LogId` for more accurate grouping of records to avoid losing uniqueness of some records (those that share `LogId` values but have different `id` and/or `ParticipantIdentifier` values)

## Minor Changes

1. Update config params to use latest external datasets version (2024-06-13)

[RMHDR-258]: https://sagebionetworks.jira.com/browse/RMHDR-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ